### PR TITLE
Do not throw an error on unknown item with crumbmenu

### DIFF
--- a/src/Lavary/Menu/Builder.php
+++ b/src/Lavary/Menu/Builder.php
@@ -584,6 +584,11 @@ class Builder
 
         $item = $this->active();
         $items = [$item];
+        
+        if ($item === null) {
+            return $nb;
+        }
+
         while ($item->hasParent()) {
             $item = $item->parent();
             array_unshift($items, $item);


### PR DESCRIPTION
If you browse to a page who is not present in your menu definition and you have a crumbmenu on that page, it will generate a error:

> Call to a member function hasParent() on null

This patch fixes this and shows no menu entries in the crumbmenu when you browse to a page without menu entry.